### PR TITLE
Remove the Query index/type encoding for complex encoding of URI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -43,4 +43,4 @@ groovyVersion = 2.3.2
 # --------------------
 # Project wide version
 # --------------------
-version=2.1.0.lambda.1-SNAPSHOT
+version=2.1.0-lambda1

--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/QueryBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/QueryBuilder.java
@@ -106,9 +106,9 @@ public class QueryBuilder {
 
     private String assemble() {
         StringBuilder sb = new StringBuilder();
-        sb.append(StringUtils.encodePath(resource.index()));
+        sb.append(resource.index());
         sb.append("/");
-        sb.append(StringUtils.encodePath(resource.type()));
+        sb.append(resource.type());
         sb.append("/_search?");
 
         // override infrastructure params

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.lambdacloud</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
   <packaging>pom</packaging>
-  <version>2.1.0.lambda.1-SNAPSHOT</version>
+  <version>2.1.0-lambda1</version>
   <name>elasticsearch-hadoop</name>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,6 @@
                              http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>com.lambdacloud</groupId>
-    <artifactId>lambda-lib</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-  </parent>
-
   <groupId>com.lambdacloud</groupId>
   <artifactId>elasticsearch-hadoop</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
The change is to keep the same requirement with Hadoop old Http client
v3.x getURI() function for the URI encoding

Signed-off-by: Zhang Wei weiz@lambdacloud.com
